### PR TITLE
feat(creator): add Xiaohongshu post generator

### DIFF
--- a/apps/daemon/src/api/routes.creator.ts
+++ b/apps/daemon/src/api/routes.creator.ts
@@ -1012,6 +1012,7 @@ function creatorArtifactContentType(fileName: string): string {
   if (extension === '.png') return 'image/png';
   if (extension === '.webp') return 'image/webp';
   if (extension === '.srt') return 'application/x-subrip; charset=utf-8';
+  if (extension === '.md') return 'text/markdown; charset=utf-8';
   if (extension === '.mp4') return 'video/mp4';
   if (extension === '.webm') return 'video/webm';
   if (extension === '.mp3') return 'audio/mpeg';

--- a/apps/daemon/src/api/server.ts
+++ b/apps/daemon/src/api/server.ts
@@ -58,6 +58,7 @@ import { createVideoExecutor } from '../creator/video/executor.js';
 import { createClipExecutor } from '../creator/clip/executor.js';
 import { createStickmanExecutor } from '../creator/stickman/executor.js';
 import { createSmartDubbingExecutor } from '../creator/smart-dubbing/executor.js';
+import { createXiaohongshuPostExecutor } from '../creator/xiaohongshu/executor.js';
 import { createCreatorProjectCoverService } from '../creator/project-cover.js';
 import { createVideoGenerationService } from '../video-generation/service.js';
 import {
@@ -591,6 +592,9 @@ export async function buildServer(input: BuildServerInput) {
     console.warn(`Creator optional runtime executors are unavailable: ${formatError(error)}`);
   }
   if (input.creatorExecutors === undefined) {
+    creatorExecutors.push(createXiaohongshuPostExecutor({
+      configStore: creatorServicesConfigStore
+    }));
     creatorExecutors.push(createSmartDubbingExecutor({
       ttsService: krillinTtsService
     }));

--- a/apps/daemon/src/creator/stage-runner.ts
+++ b/apps/daemon/src/creator/stage-runner.ts
@@ -487,6 +487,7 @@ function resultSnapshotDescription(stageId: string, templateId: string): string 
   if (stageId === 'generate') {
     if (templateId === 'cover') return '生成封面';
     if (templateId === 'video-generation') return '生成视频';
+    if (templateId === 'xiaohongshu-post') return '生成小红书帖子';
     return '生成图片';
   }
   return `完成 ${stageId}`;

--- a/apps/daemon/src/creator/templates/registry.ts
+++ b/apps/daemon/src/creator/templates/registry.ts
@@ -12,6 +12,7 @@ import { createVideoGenerationTemplate } from './video-generation.js';
 import { createAutoClipTemplate } from './auto-clip.js';
 import { createStickmanVideoTemplate } from './stickman-video.js';
 import { createSmartDubbingTemplate } from './smart-dubbing.js';
+import { createXiaohongshuPostTemplate } from './xiaohongshu-post.js';
 import type {
   CreatorTemplateDefinition,
   CreatorTemplateRegistry
@@ -26,6 +27,7 @@ export {
   createVideoGenerationTemplate,
   createStickmanVideoTemplate,
   createSmartDubbingTemplate,
+  createXiaohongshuPostTemplate,
   createLegacyVideoDownloadTemplate,
   createVideoDownloadTemplate,
   createVideoTranslationTemplate
@@ -41,6 +43,7 @@ export function createDefaultCreatorTemplateRegistry(): CreatorTemplateRegistry 
     createLegacyImageGenerationTemplate(),
     createImageGenerationTemplate(),
     createSmartDubbingTemplate(),
+    createXiaohongshuPostTemplate(),
     createVideoGenerationTemplate(),
     createAutoClipTemplate(),
     createStickmanVideoTemplate()

--- a/apps/daemon/src/creator/templates/xiaohongshu-post.ts
+++ b/apps/daemon/src/creator/templates/xiaohongshu-post.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import type { CreatorTemplateDefinition } from './types.js';
+
+const record = z.record(z.string(), z.unknown()) as never;
+
+export function createXiaohongshuPostTemplate(): CreatorTemplateDefinition {
+  return {
+    id: 'xiaohongshu-post',
+    version: 1,
+    renderer: 'xiaohongshu-post',
+    inputSchema: z.object({
+      topic: z.string().max(5_000).default(''),
+      audience: z.string().max(500).default(''),
+      style: z.enum(['experience', 'tutorial', 'recommendation', 'review']).default('experience'),
+      length: z.enum(['short', 'medium', 'long']).default('medium'),
+      extraRequirements: z.string().max(2_000).default(''),
+      currentStage: z.string().nullable().default(null)
+    }).passthrough() as never,
+    stages: [{
+      id: 'generate',
+      executor: 'xiaohongshu-post',
+      allowedJobStatuses: ['draft', 'running', 'completed', 'failed', 'needs_input'],
+      inputArtifacts: [],
+      outputArtifacts: [{ kind: 'xiaohongshu_post', status: 'completed' }]
+    }],
+    actions: [
+      { id: 'update-settings', inputSchema: record, allowedStages: ['generate'] },
+      { id: 'run-stage', inputSchema: record, allowedStages: ['generate'] },
+      { id: 'undo-action', inputSchema: record, allowedStages: ['generate'] }
+    ],
+    outputs: [{ kind: 'xiaohongshu_post', required: true }],
+    agentGuidance: [
+      '帮助用户生成可直接修改和发布的小红书帖子。',
+      '更新设置必须写入 input.patch，可调整 topic、audience、style、length 和 extraRequirements。',
+      'topic 是必填的创作主题或素材；确认要求后运行 generate 阶段。',
+      '不得伪造用户未提供的亲身经历、产品功效、价格或数据。'
+    ].join(' ')
+  };
+}

--- a/apps/daemon/src/creator/xiaohongshu/executor.ts
+++ b/apps/daemon/src/creator/xiaohongshu/executor.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'node:crypto';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { z } from 'zod';
+import type { CreatorJson } from '@opencreator/protocol';
+import type { CreatorServicesConfigStore } from '../../creator-services/config-store.js';
+import {
+  creatorServiceErrorMessage,
+  fetchCreatorService,
+  openAiCompatibleEndpoint
+} from '../../creator-services/upstream-fetch.js';
+import type { CreatorExecutor } from '../executor.js';
+import { CreatorExecutorError } from '../executor.js';
+
+const generatedPostSchema = z.object({
+  title: z.string().trim().min(1).max(80),
+  body: z.string().trim().min(1).max(20_000),
+  hashtags: z.array(z.string().trim().min(1).max(40)).max(12).default([])
+}).strict();
+
+type XiaohongshuStyle = 'experience' | 'tutorial' | 'recommendation' | 'review';
+type XiaohongshuLength = 'short' | 'medium' | 'long';
+
+export function createXiaohongshuPostExecutor(input: {
+  configStore: Pick<CreatorServicesConfigStore, 'read'>;
+  fetchImpl?: typeof fetch;
+}): CreatorExecutor {
+  return {
+    id: 'xiaohongshu-post',
+    async run(stage) {
+      stage.reportProgress({ phase: 'validating', percent: 5 });
+      const request = readRequest(stage.job.state);
+      const config = await input.configStore.read();
+      if (!config.llm.apiKey.trim()) {
+        throw new CreatorExecutorError(
+          'creator_llm_config_missing',
+          'LLM configuration is incomplete'
+        );
+      }
+      stage.reportProgress({ phase: 'generating_post', percent: 20 });
+      try {
+        const response = await fetchCreatorService({
+          endpoint: openAiCompatibleEndpoint(config.llm.baseUrl, 'chat/completions'),
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${config.llm.apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            model: config.llm.model,
+            response_format: { type: 'json_object' },
+            messages: [{
+              role: 'user',
+              content: postPrompt(request)
+            }]
+          }),
+          proxy: config.proxy,
+          signal: stage.signal,
+          maxResponseBytes: 2 * 1024 * 1024,
+          ...(input.fetchImpl === undefined ? {} : { fetchImpl: input.fetchImpl })
+        });
+        if (!response.ok) {
+          throw new CreatorExecutorError(
+            'creator_llm_upstream_error',
+            await creatorServiceErrorMessage(response, 'Post generation')
+          );
+        }
+        const payload = await response.json() as {
+          choices?: Array<{ message?: { content?: string } }>;
+        };
+        const content = payload.choices?.[0]?.message?.content;
+        if (!content) {
+          throw new CreatorExecutorError(
+            'creator_llm_upstream_error',
+            'Post generation returned no content'
+          );
+        }
+        const post = generatedPostSchema.parse(JSON.parse(content));
+        const markdown = formatPost(post);
+        const fileName = 'OpenCreator-xiaohongshu-post.md';
+        const path = join(stage.workdir, fileName);
+        await writeFile(path, markdown, { encoding: 'utf8', mode: 0o600 });
+        return {
+          outputs: [{
+            kind: 'xiaohongshu_post',
+            status: 'completed',
+            path,
+            metadata: {
+              fileName,
+              mimeType: 'text/markdown',
+              bytes: Buffer.byteLength(markdown),
+              sha256: createHash('sha256').update(markdown).digest('hex'),
+              title: post.title,
+              hashtags: normalizedHashtags(post.hashtags),
+              characterCount: [...post.body].length,
+              model: config.llm.model,
+              settingsSnapshot: stage.job.state
+            }
+          }],
+          progress: {
+            phase: 'completed',
+            percent: 100,
+            completed: 1,
+            failed: 0,
+            total: 1
+          }
+        };
+      } catch (error) {
+        if (stage.signal.aborted) {
+          throw new CreatorExecutorError('creator_stage_canceled', 'Creator stage was canceled');
+        }
+        if (error instanceof CreatorExecutorError) throw error;
+        throw new CreatorExecutorError(
+          'creator_llm_upstream_error',
+          error instanceof Error ? error.message : 'Post generation failed'
+        );
+      }
+    }
+  };
+}
+
+function readRequest(state: Record<string, CreatorJson>): {
+  topic: string;
+  audience: string;
+  style: XiaohongshuStyle;
+  length: XiaohongshuLength;
+  extraRequirements: string;
+} {
+  const topic = readString(state.topic);
+  if (!topic || [...topic].length > 5_000) {
+    throw new CreatorExecutorError(
+      'creator_stage_input_missing',
+      'Post topic must contain between 1 and 5000 characters'
+    );
+  }
+  const style = state.style;
+  const length = state.length;
+  if (!['experience', 'tutorial', 'recommendation', 'review'].includes(String(style))) {
+    throw new CreatorExecutorError('creator_stage_input_missing', 'Post style is invalid');
+  }
+  if (!['short', 'medium', 'long'].includes(String(length))) {
+    throw new CreatorExecutorError('creator_stage_input_missing', 'Post length is invalid');
+  }
+  return {
+    topic,
+    audience: readString(state.audience) ?? '',
+    style: style as XiaohongshuStyle,
+    length: length as XiaohongshuLength,
+    extraRequirements: readString(state.extraRequirements) ?? ''
+  };
+}
+
+function postPrompt(request: ReturnType<typeof readRequest>): string {
+  const styleLabels: Record<XiaohongshuStyle, string> = {
+    experience: '经验分享',
+    tutorial: '教程干货',
+    recommendation: '产品种草',
+    review: '真实测评'
+  };
+  const lengthLabels: Record<XiaohongshuLength, string> = {
+    short: '精简，约 300-500 字',
+    medium: '标准，约 600-900 字',
+    long: '详细，约 1000-1500 字'
+  };
+  return [
+    '生成一篇中文小红书帖子，只输出严格 JSON。',
+    '格式：{"title":"标题","body":"正文","hashtags":["标签"]}。',
+    '正文要自然、具体、便于阅读；可以分段和使用少量 emoji，但不要堆砌口号。',
+    '标签不要带 #，只保留与内容直接相关的标签。',
+    '必须忠于用户提供的素材，不得虚构亲身经历、产品功效、价格、数据或引用。',
+    `内容类型：${styleLabels[request.style]}。`,
+    `篇幅：${lengthLabels[request.length]}。`,
+    request.audience ? `目标读者：${request.audience}` : '目标读者：根据主题合理判断。',
+    request.extraRequirements ? `补充要求：${request.extraRequirements}` : '没有其他补充要求。',
+    `主题或素材：${request.topic}`
+  ].join('\n');
+}
+
+function formatPost(post: z.infer<typeof generatedPostSchema>): string {
+  const tags = normalizedHashtags(post.hashtags).map(tag => `#${tag}`).join(' ');
+  return `${[`# ${post.title}`, post.body, tags].filter(Boolean).join('\n\n')}\n`;
+}
+
+function normalizedHashtags(hashtags: string[]): string[] {
+  return [...new Set(hashtags.map(tag => tag.replace(/^#+/, '').trim()).filter(Boolean))];
+}
+
+function readString(value: CreatorJson | undefined): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/apps/daemon/src/creator/xiaohongshu/executor.ts
+++ b/apps/daemon/src/creator/xiaohongshu/executor.ts
@@ -12,9 +12,12 @@ import {
 import type { CreatorExecutor } from '../executor.js';
 import { CreatorExecutorError } from '../executor.js';
 
+const XIAOHONGSHU_TITLE_MAX_LENGTH = 20;
+const XIAOHONGSHU_BODY_MAX_LENGTH = 1_000;
+
 const generatedPostSchema = z.object({
-  title: z.string().trim().min(1).max(80),
-  body: z.string().trim().min(1).max(20_000),
+  title: z.string().trim().min(1).max(XIAOHONGSHU_TITLE_MAX_LENGTH),
+  body: z.string().trim().min(1).max(XIAOHONGSHU_BODY_MAX_LENGTH),
   hashtags: z.array(z.string().trim().min(1).max(40)).max(12).default([])
 }).strict();
 
@@ -159,12 +162,13 @@ function postPrompt(request: ReturnType<typeof readRequest>): string {
   };
   const lengthLabels: Record<XiaohongshuLength, string> = {
     short: '精简，约 300-500 字',
-    medium: '标准，约 600-900 字',
-    long: '详细，约 1000-1500 字'
+    medium: '标准，约 600-800 字',
+    long: '详细，约 800-1000 字'
   };
   return [
     '生成一篇中文小红书帖子，只输出严格 JSON。',
     '格式：{"title":"标题","body":"正文","hashtags":["标签"]}。',
+    `标题不超过 ${XIAOHONGSHU_TITLE_MAX_LENGTH} 个字符，正文不超过 ${XIAOHONGSHU_BODY_MAX_LENGTH} 个字符。`,
     '正文要自然、具体、便于阅读；可以分段和使用少量 emoji，但不要堆砌口号。',
     '标签不要带 #，只保留与内容直接相关的标签。',
     '必须忠于用户提供的素材，不得虚构亲身经历、产品功效、价格、数据或引用。',

--- a/apps/daemon/test/integration/creator-xiaohongshu-post.test.ts
+++ b/apps/daemon/test/integration/creator-xiaohongshu-post.test.ts
@@ -1,10 +1,11 @@
 import { createDefaultCreatorServicesConfig } from '@opencreator/protocol';
 import type { FastifyInstance } from 'fastify';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildServer } from '../../src/api/server.js';
+import type { CreatorExecutorInput } from '../../src/creator/executor.js';
 import { createXiaohongshuPostExecutor } from '../../src/creator/xiaohongshu/executor.js';
 
 let server: FastifyInstance | undefined;
@@ -122,6 +123,8 @@ describe('creator xiaohongshu post', () => {
     });
     expect(requestBody.messages[0].content).toContain('分享第一次参与开源项目的过程');
     expect(requestBody.messages[0].content).toContain('不得虚构');
+    expect(requestBody.messages[0].content).toContain('标题不超过 20 个字符');
+    expect(requestBody.messages[0].content).toContain('正文不超过 1000 个字符');
 
     const artifact = completed.artifacts.find((item: { kind: string }) => (
       item.kind === 'xiaohongshu_post'
@@ -151,6 +154,45 @@ describe('creator xiaohongshu post', () => {
       '#开源 #程序员',
       ''
     ].join('\n'));
+  });
+
+  it.each([
+    ['title', '超'.repeat(21), '有效正文'],
+    ['body', '有效标题', '超'.repeat(1_001)]
+  ])('rejects generated %s beyond the Xiaohongshu publishing limit', async (_field, title, body) => {
+    tempDir = await mkdtemp(join(tmpdir(), 'creator-xiaohongshu-post-limit-'));
+    const config = createDefaultCreatorServicesConfig();
+    config.llm.apiKey = 'text-key';
+    config.llm.model = 'test-model';
+    const executor = createXiaohongshuPostExecutor({
+      configStore: {
+        async read() { return structuredClone(config); }
+      },
+      fetchImpl: vi.fn(async () => new Response(JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({ title, body, hashtags: [] }) } }]
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      }))
+    });
+
+    await expect(executor.run({
+      job: {
+        state: {
+          topic: '测试发布长度限制',
+          audience: '',
+          style: 'experience',
+          length: 'short',
+          extraRequirements: ''
+        }
+      },
+      workdir: tempDir,
+      signal: new AbortController().signal,
+      reportProgress: vi.fn()
+    } as unknown as CreatorExecutorInput)).rejects.toMatchObject({
+      code: 'creator_llm_upstream_error'
+    });
+    expect(await readdir(tempDir)).toEqual([]);
   });
 });
 

--- a/apps/daemon/test/integration/creator-xiaohongshu-post.test.ts
+++ b/apps/daemon/test/integration/creator-xiaohongshu-post.test.ts
@@ -1,0 +1,184 @@
+import { createDefaultCreatorServicesConfig } from '@opencreator/protocol';
+import type { FastifyInstance } from 'fastify';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildServer } from '../../src/api/server.js';
+import { createXiaohongshuPostExecutor } from '../../src/creator/xiaohongshu/executor.js';
+
+let server: FastifyInstance | undefined;
+let tempDir = '';
+
+afterEach(async () => {
+  await server?.close();
+  server = undefined;
+  if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  tempDir = '';
+});
+
+describe('creator xiaohongshu post', () => {
+  it('generates a downloadable Markdown post through Creator Runtime', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'creator-xiaohongshu-post-'));
+    const config = createDefaultCreatorServicesConfig();
+    config.llm.apiKey = 'text-key';
+    config.llm.model = 'test-model';
+    config.llm.source = 'custom';
+    const fetchImpl = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => new Response(JSON.stringify({
+      choices: [{
+        message: {
+          content: JSON.stringify({
+            title: '第一次参加开源项目，我学到了什么',
+            body: '从一个边界清楚的小功能开始，先确认需求，再完成实现和验证。',
+            hashtags: ['开源', '#程序员', '开源']
+          })
+        }
+      }]
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    }));
+    server = await buildServer({
+      token: 'secret',
+      dataDir: tempDir,
+      codexHome: join(tempDir, 'codex-home'),
+      creatorExecutors: [createXiaohongshuPostExecutor({
+        configStore: {
+          async read() { return structuredClone(config); }
+        },
+        fetchImpl
+      })],
+      creatorServicesConfigStore: {
+        async read() { return structuredClone(config); },
+        async write(next) { return structuredClone(next); },
+        async reset() { return structuredClone(config); }
+      },
+      codexProviderCredentialStore: {
+        async readApiKey() { return undefined; },
+        async writeApiKey() {}
+      }
+    });
+
+    const templates = await request('GET', '/creator/templates');
+    expect(templates.json().templates).toContainEqual(expect.objectContaining({
+      id: 'xiaohongshu-post',
+      outputs: [{ kind: 'xiaohongshu_post', required: true }]
+    }));
+
+    const created = await request('POST', '/creator/jobs', {
+      projectId: 'project_xiaohongshu',
+      templateId: 'xiaohongshu-post'
+    });
+    const initial = created.json().job;
+    const updated = await request('POST', `/creator/jobs/${initial.id}/actions`, {
+      action: 'update-settings',
+      expectedRevision: initial.revision,
+      input: {
+        patch: {
+          topic: '分享第一次参与开源项目的过程',
+          audience: '准备参与开源项目的程序员',
+          style: 'experience',
+          length: 'short',
+          extraRequirements: '语气真诚，不夸大'
+        }
+      }
+    });
+    await request('POST', `/creator/jobs/${initial.id}/actions`, {
+      action: 'run-stage',
+      expectedRevision: updated.json().job.revision,
+      input: { stageId: 'generate' }
+    });
+
+    const completed = await waitForCompletedJob(initial.id);
+    expect(completed).toMatchObject({
+      status: 'completed',
+      state: {
+        latestResultVersion: 1,
+        resultSnapshots: [{
+          version: 1,
+          stageId: 'generate',
+          description: '生成小红书帖子',
+          artifactRefs: { xiaohongshu_post: [expect.any(String)] }
+        }]
+      },
+      stages: [{
+        stageId: 'generate',
+        executor: 'xiaohongshu-post',
+        status: 'succeeded',
+        progress: {
+          phase: 'completed',
+          percent: 100,
+          completed: 1,
+          failed: 0,
+          total: 1
+        }
+      }]
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const requestBody = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body));
+    expect(requestBody).toMatchObject({
+      model: 'test-model',
+      response_format: { type: 'json_object' }
+    });
+    expect(requestBody.messages[0].content).toContain('分享第一次参与开源项目的过程');
+    expect(requestBody.messages[0].content).toContain('不得虚构');
+
+    const artifact = completed.artifacts.find((item: { kind: string }) => (
+      item.kind === 'xiaohongshu_post'
+    ));
+    expect(artifact).toMatchObject({
+      status: 'completed',
+      metadata: {
+        fileName: 'OpenCreator-xiaohongshu-post.md',
+        mimeType: 'text/markdown',
+        title: '第一次参加开源项目，我学到了什么',
+        hashtags: ['开源', '程序员'],
+        model: 'test-model',
+        resultVersion: 1
+      }
+    });
+    const content = await request(
+      'GET',
+      `/creator/jobs/${initial.id}/artifacts/${artifact.id}/content`
+    );
+    expect(content.statusCode).toBe(200);
+    expect(content.headers['content-type']).toContain('text/markdown');
+    expect(content.rawPayload.toString('utf8')).toBe([
+      '# 第一次参加开源项目，我学到了什么',
+      '',
+      '从一个边界清楚的小功能开始，先确认需求，再完成实现和验证。',
+      '',
+      '#开源 #程序员',
+      ''
+    ].join('\n'));
+  });
+});
+
+async function waitForCompletedJob(jobId: string) {
+  const deadline = Date.now() + 10_000;
+  let lastJob: unknown;
+  while (Date.now() < deadline) {
+    const response = await request('GET', `/creator/jobs/${jobId}`);
+    const job = response.json().job;
+    lastJob = job;
+    if (job.status === 'completed') return job;
+    if (job.status === 'failed' || job.status === 'needs_input') {
+      throw new Error(`Xiaohongshu post generation failed: ${JSON.stringify(job)}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for Xiaohongshu post: ${JSON.stringify(lastJob)}`);
+}
+
+async function request(
+  method: 'GET' | 'POST',
+  url: string,
+  payload?: object
+): Promise<{ statusCode: number; headers: Record<string, string>; json(): any; rawPayload: Buffer }> {
+  return await server!.inject({
+    method,
+    url,
+    headers: { authorization: 'Bearer secret' },
+    ...(payload === undefined ? {} : { payload })
+  }) as never;
+}

--- a/apps/daemon/test/unit/creator-template-registry.test.ts
+++ b/apps/daemon/test/unit/creator-template-registry.test.ts
@@ -4,6 +4,7 @@ import {
   createImageGenerationTemplate,
   createCreatorTemplateRegistry,
   createSmartDubbingTemplate,
+  createXiaohongshuPostTemplate,
   createVideoDownloadTemplate,
   createVideoGenerationTemplate,
   createVideoTranslationTemplate
@@ -94,6 +95,30 @@ describe('creator template registry', () => {
       furthestStep: 0
     });
     expect(template.inputSchema.parse({})).not.toHaveProperty('ttsProvider');
+  });
+
+  it('registers Xiaohongshu post generation as a persisted text workflow', () => {
+    const template = createXiaohongshuPostTemplate();
+
+    expect(template).toMatchObject({
+      id: 'xiaohongshu-post',
+      version: 1,
+      renderer: 'xiaohongshu-post',
+      stages: [{
+        id: 'generate',
+        executor: 'xiaohongshu-post',
+        outputArtifacts: [{ kind: 'xiaohongshu_post', status: 'completed' }]
+      }],
+      outputs: [{ kind: 'xiaohongshu_post', required: true }]
+    });
+    expect(template.inputSchema.parse({})).toMatchObject({
+      topic: '',
+      audience: '',
+      style: 'experience',
+      length: 'medium',
+      extraRequirements: '',
+      currentStage: null
+    });
   });
 
   it('registers video download v2 with a non-final probe and controlled choices', () => {

--- a/apps/web/e2e/web-desktop-parity.spec.ts
+++ b/apps/web/e2e/web-desktop-parity.spec.ts
@@ -332,6 +332,112 @@ test('视频生成在 Browser/Desktop Bridge 下保持相同界面、请求和�
   expect(results[1]!.state).toEqual(results[0]!.state);
 });
 
+test('小红书帖子在 Browser/Desktop Bridge 下保持相同界面、请求和持久状态', async ({
+  browser,
+  runtime
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'chromium-desktop',
+    '一致性规格内部固定创建 Browser/Desktop Chromium 上下文'
+  );
+
+  const results: Array<{
+    text: string;
+    boxes: Record<string, { x: number; y: number; width: number; height: number }>;
+    requests: string[];
+    state: Record<string, unknown>;
+  }> = [];
+
+  for (const platform of ['browser', 'desktop'] as const) {
+    const created = await runtime.api<{
+      job: { id: string };
+    }>('POST', '/creator/jobs', {
+      projectId: runtime.projectId,
+      templateId: 'xiaohongshu-post'
+    });
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 800 },
+      deviceScaleFactor: 1,
+      colorScheme: 'dark',
+      reducedMotion: 'reduce'
+    });
+    const page = await context.newPage();
+    if (platform === 'desktop') await installDesktopBridge(page);
+
+    try {
+      await runtime.openApp(page);
+      const requests: string[] = [];
+      page.on('request', request => {
+        const url = new URL(request.url());
+        if (!url.pathname.includes('/creator/')) return;
+        requests.push(
+          `${request.method()} ${url.pathname
+            .replace('/.opencreator/runtime', '')
+            .replace(created.job.id, '{jobId}')}`
+        );
+      });
+      await page.goto(
+        `${runtime.origin}/#/workbench?tool=xiaohongshu-post`
+        + `&jobId=${encodeURIComponent(created.job.id)}`
+      );
+
+      const workspace = page.getByRole('region', { name: '小红书帖子生成器 操作区' });
+      const panel = page.getByRole('complementary', { name: 'OpenCreator' });
+      const topic = workspace.getByRole('textbox', { name: '小红书帖子主题或素材' });
+      await topic.fill('第一次参与开源项目的真实过程');
+      await workspace.getByRole('radio', { name: '教程干货' }).click();
+      await workspace.getByRole('radio', { name: '精简' }).click();
+
+      await expect.poll(async () => (
+        await runtime.api<{
+          job: { state: Record<string, unknown> };
+        }>('GET', `/creator/jobs/${encodeURIComponent(created.job.id)}`)
+      ).job.state).toMatchObject({
+        topic: '第一次参与开源项目的真实过程',
+        style: 'tutorial',
+        length: 'short'
+      });
+
+      const boxes: Record<
+        string,
+        { x: number; y: number; width: number; height: number }
+      > = {};
+      for (const [name, locator] of [
+        ['workspace', workspace],
+        ['panel', panel],
+        ['topic', topic]
+      ] as const) {
+        const box = await locator.boundingBox();
+        expect(box, `${platform} 缺少 ${name} 尺寸目标`).not.toBeNull();
+        boxes[name] = {
+          x: Math.round(box!.x),
+          y: Math.round(box!.y),
+          width: Math.round(box!.width),
+          height: Math.round(box!.height)
+        };
+      }
+      const persisted = await runtime.api<{
+        job: { state: Record<string, unknown> };
+      }>('GET', `/creator/jobs/${encodeURIComponent(created.job.id)}`);
+      results.push({
+        text: normalizeParityText(
+          `${await workspace.innerText()}\n${await panel.innerText()}`
+        ),
+        boxes,
+        requests,
+        state: persisted.job.state
+      });
+    } finally {
+      await context.close();
+    }
+  }
+
+  expect(results[1]!.text).toBe(results[0]!.text);
+  expect(results[1]!.boxes).toEqual(results[0]!.boxes);
+  expect(results[1]!.requests).toEqual(results[0]!.requests);
+  expect(results[1]!.state).toEqual(results[0]!.state);
+});
+
 test('第三方组件设置在 Browser/Desktop Bridge 下保持相同状态、尺寸和 Runtime 请求', async ({
   browser,
   runtime

--- a/apps/web/src/features/dashboard/CreatorCollaborationPanel.test.tsx
+++ b/apps/web/src/features/dashboard/CreatorCollaborationPanel.test.tsx
@@ -6,6 +6,7 @@ import CreatorCollaborationPanel from './CreatorCollaborationPanel.js';
 import {
   coverPanelAdapter,
   smartDubbingPanelAdapter,
+  xiaohongshuPostPanelAdapter,
   videoDownloadPanelAdapter,
   videoGenerationPanelAdapter
 } from './creator-panel-adapters.js';
@@ -453,7 +454,116 @@ describe('CreatorCollaborationPanel', () => {
     expect(screen.getByRole('button', { name: '终止生成配音' })).toBeInTheDocument();
     expect(container.querySelectorAll('.creator-collaboration-stage')).toHaveLength(1);
   });
+
+  it('语义化并合并小红书设置动态，同时显示真实生成进度', () => {
+    render(
+      <LanguageProvider initialPreference="zh-CN">
+        <CreatorSessionProvider
+          initialJob={xiaohongshuPostJob()}
+          service={{
+            applyAction: vi.fn(),
+            runAgentTurn: vi.fn()
+          } as never}
+        >
+          <CreatorCollaborationPanel
+            adapter={xiaohongshuPostPanelAdapter}
+            stepLabel="正在生成帖子"
+            contextSummary="教程干货 · 精简"
+          />
+        </CreatorSessionProvider>
+      </LanguageProvider>
+    );
+
+    expect(screen.getAllByText('更新了创作设置')).toHaveLength(1);
+    expect(screen.getByText('主题或素材、内容类型')).toBeInTheDocument();
+    expect(screen.getByText('2 次修改')).toBeInTheDocument();
+    expect(screen.queryByText(/currentStep/)).not.toBeInTheDocument();
+    expect(screen.getByText(/系统 · 生成小红书帖子/)).toBeInTheDocument();
+    expect(screen.getByText('生成帖子内容')).toBeInTheDocument();
+    expect(screen.getByText('20%')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: '生成小红书帖子进度' }))
+      .toHaveAttribute('aria-valuenow', '20');
+  });
 });
+
+function xiaohongshuPostJob(): CreatorJob {
+  const createdAt = '2026-09-08T08:00:00.000Z';
+  return {
+    id: 'xiaohongshu_job',
+    projectId: 'project_1',
+    templateId: 'xiaohongshu-post',
+    templateVersion: 1,
+    status: 'running',
+    revision: 4,
+    state: {
+      topic: '第一次参与开源项目',
+      audience: '准备参与开源项目的程序员',
+      style: 'tutorial',
+      length: 'short',
+      extraRequirements: '',
+      currentStage: 'generate'
+    },
+    agentThreadId: null,
+    stages: [{
+      id: 'xiaohongshu_stage',
+      jobId: 'xiaohongshu_job',
+      stageId: 'generate',
+      executor: 'xiaohongshu-post',
+      status: 'running',
+      dispatchStatus: 'claimed',
+      claimOwner: 'scheduler_1',
+      claimExpiresAt: null,
+      attempt: 1,
+      idempotencyKey: 'xiaohongshu-1',
+      progress: {
+        phase: 'generating_post',
+        percent: 20,
+        completed: 0,
+        failed: 0,
+        total: 1
+      },
+      errorCode: null,
+      errorMessage: null,
+      startedAt: '2026-09-08T08:00:03.000Z',
+      finishedAt: null
+    }],
+    artifacts: [],
+    activities: [
+      {
+        id: 'activity_topic_1',
+        jobId: 'xiaohongshu_job',
+        revision: 1,
+        actor: 'user',
+        action: 'update-settings:draft',
+        summary: '更新创作设置',
+        details: { objectId: 'topic,style' },
+        createdAt: '2026-09-08T08:00:01.000Z'
+      },
+      {
+        id: 'activity_topic_2',
+        jobId: 'xiaohongshu_job',
+        revision: 2,
+        actor: 'user',
+        action: 'update-settings:draft',
+        summary: '更新创作设置',
+        details: { objectId: 'topic,style' },
+        createdAt: '2026-09-08T08:00:02.000Z'
+      },
+      {
+        id: 'activity_ui',
+        jobId: 'xiaohongshu_job',
+        revision: 3,
+        actor: 'user',
+        action: 'update-settings:draft',
+        summary: '更新创作设置',
+        details: { objectId: 'currentStep' },
+        createdAt: '2026-09-08T08:00:02.500Z'
+      }
+    ],
+    createdAt,
+    updatedAt: '2026-09-08T08:00:03.000Z'
+  };
+}
 
 function smartDubbingJob(): CreatorJob {
   const createdAt = '2026-09-07T08:00:00.000Z';

--- a/apps/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.test.tsx
@@ -728,11 +728,12 @@ describe('DashboardPage', () => {
     expect(within(videoTranslationCard).getByText('HOT')).toBeInTheDocument();
     expect(within(videoTranslationCard).queryByText('NEW')).not.toBeInTheDocument();
     const appCards = Array.from(container.querySelectorAll('.dashboard-app-card'));
-    expect(appCards).toHaveLength(6);
+    expect(appCards).toHaveLength(7);
     expect(appCards.map(card => card.querySelector('strong')?.textContent)).toEqual([
       '视频翻译',
       '视频下载',
       '封面生成',
+      '小红书帖子',
       '智能配音',
       '视频生成',
       '图像生成'

--- a/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -10,6 +10,7 @@ import {
   ImagePlus,
   Languages,
   Mic2,
+  PenLine,
   Search,
   ServerOff,
   Sparkles,
@@ -23,6 +24,7 @@ import CoverGeneratorWorkspace from './CoverGeneratorWorkspace.js';
 import DigitalAvatarWorkspace from './DigitalAvatarWorkspace.js';
 import ImageGenerationWorkspace from './ImageGenerationWorkspace.js';
 import SmartDubbingWorkspace from './SmartDubbingWorkspace.js';
+import XiaohongshuPostWorkspace from './XiaohongshuPostWorkspace.js';
 import StickmanVideoWorkspace from './StickmanVideoWorkspace.js';
 import VideoDownloadWorkspace from './VideoDownloadWorkspace.js';
 import VideoTranslationWorkspace from './VideoTranslationWorkspace.js';
@@ -42,7 +44,7 @@ import {
 import type { VideoMetadataService } from '../../services/video-metadata-service.js';
 import type { CreatorServicesSettingsService } from '../../services/creator-services-service.js';
 
-type DashboardCategory = '视频创作' | '图像创作' | '音频处理' | '视频编辑' | '数字人';
+type DashboardCategory = '视频创作' | '图像创作' | '文案创作' | '音频处理' | '视频编辑' | '数字人';
 
 type DashboardEntry = {
   title: string;
@@ -127,6 +129,15 @@ const creatorTools: DashboardEntry[] = [
     workspace: 'cover-generator'
   },
   {
+    title: '小红书帖子',
+    description: '从主题和素材生成完整帖子',
+    prompt: '帮我写一篇小红书帖子，请先确认主题、目标读者、内容类型和篇幅。',
+    category: '文案创作',
+    icon: PenLine,
+    badge: 'NEW',
+    workspace: 'xiaohongshu-post'
+  },
+  {
     title: '智能配音',
     description: '自然音色与情绪表达',
     prompt: '帮我为这段内容制作配音，请根据使用场景优化文本、语速、停顿和情绪。',
@@ -160,7 +171,7 @@ const creatorTools: DashboardEntry[] = [
   },
 ];
 
-const categories = ['全部', '视频创作', '视频编辑', '图像创作', '音频处理'] as const;
+const categories = ['全部', '视频创作', '视频编辑', '图像创作', '文案创作', '音频处理'] as const;
 type CategoryFilter = typeof categories[number];
 
 const CREATOR_JOB_LOAD_TIMEOUT_MS = 15_000;
@@ -311,6 +322,15 @@ export default function DashboardPage(props: {
       <SmartDubbingWorkspace
         promptHint={activePromptHint}
         creatorServicesService={props.creatorServicesService}
+        onBack={closeWorkspace}
+      />
+    ));
+  }
+
+  if (activeWorkspace === 'xiaohongshu-post') {
+    return renderCreatorWorkspace('xiaohongshu-post', (
+      <XiaohongshuPostWorkspace
+        promptHint={activePromptHint}
         onBack={closeWorkspace}
       />
     ));
@@ -802,6 +822,7 @@ const englishDashboardLabels: Record<string, string> = {
   全部: 'All',
   视频创作: 'Video Creation',
   图像创作: 'Image Creation',
+  文案创作: 'Writing',
   音频处理: 'Audio',
   视频编辑: 'Video Editing',
   数字人: 'Avatars',
@@ -817,6 +838,8 @@ const englishDashboardLabels: Record<string, string> = {
   自动剪辑: 'Auto Clips',
   语义识别与高光切片: 'Semantic detection and highlight clips',
   智能配音: 'AI Dubbing',
+  小红书帖子: 'Xiaohongshu Posts',
+  从主题和素材生成完整帖子: 'Turn a topic or source material into a complete post',
   自然音色与情绪表达: 'Natural voices with expressive delivery',
   图像生成: 'Image Generation',
   生成创意图片与视觉素材: 'Generate images and visual assets',

--- a/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.test.tsx
+++ b/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.test.tsx
@@ -1,0 +1,277 @@
+import type { CreatorActionRequest, CreatorArtifact, CreatorJob } from '@opencreator/protocol';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LanguageProvider } from '../../i18n/LanguageProvider.js';
+import XiaohongshuPostWorkspace from './XiaohongshuPostWorkspace.js';
+import {
+  CreatorSessionProvider,
+  useOptionalCreatorSession
+} from './creator-session-store.js';
+
+describe('XiaohongshuPostWorkspace', () => {
+  it('saves settings, generates a post, and copies the real artifact content', async () => {
+    const copy = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: copy }
+    });
+    const markdown = '# 第一次参与开源项目\n\n先确认方向，再完成一个小闭环。\n\n#开源 #程序员\n';
+    let current = initialJob();
+    const applyAction = vi.fn(async (_jobId: string, request: CreatorActionRequest) => {
+      if (request.action === 'update-settings') {
+        current = {
+          ...current,
+          revision: current.revision + 1,
+          state: { ...current.state, ...(request.input.patch as CreatorJob['state']) }
+        };
+      }
+      if (request.action === 'run-stage') current = completedJob(current);
+      return {
+        job: current,
+        receipt: {
+          actor: request.actor ?? 'user' as const,
+          action: request.action,
+          summary: request.action,
+          affectedArtifacts: [],
+          newRevision: current.revision,
+          createdAt: current.updatedAt
+        }
+      };
+    });
+    const openArtifact = vi.fn(async () => new Response(markdown, {
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8' }
+    }));
+
+    render(
+      <LanguageProvider initialPreference="zh-CN">
+        <CreatorSessionProvider
+          initialJob={current}
+          service={{ applyAction, openArtifact, runAgentTurn: vi.fn() }}
+        >
+          <XiaohongshuPostWorkspace onBack={vi.fn()} />
+        </CreatorSessionProvider>
+      </LanguageProvider>
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: '小红书帖子主题或素材' }), {
+      target: { value: '分享第一次参与开源项目的过程' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('例如：准备参与开源项目的程序员'), {
+      target: { value: '准备参与开源项目的程序员' }
+    });
+    fireEvent.click(screen.getByRole('radio', { name: '教程干货' }));
+    fireEvent.click(screen.getByRole('radio', { name: '精简' }));
+    fireEvent.click(screen.getByRole('button', { name: '生成帖子' }));
+
+    expect(await screen.findByRole('textbox', { name: '生成的小红书帖子' })).toHaveValue(markdown);
+    expect(openArtifact).toHaveBeenCalledWith('xiaohongshu_job', 'xiaohongshu_post_v1');
+    expect(applyAction).toHaveBeenLastCalledWith(
+      'xiaohongshu_job',
+      expect.objectContaining({
+        action: 'run-stage',
+        input: { stageId: 'generate' }
+      })
+    );
+    expect(current.state).toMatchObject({
+      topic: '分享第一次参与开源项目的过程',
+      audience: '准备参与开源项目的程序员',
+      style: 'tutorial',
+      length: 'short'
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '复制帖子' }));
+    await waitFor(() => expect(copy).toHaveBeenCalledWith(markdown));
+    expect(screen.getByText('帖子已复制到剪贴板')).toBeInTheDocument();
+  });
+
+  it('uses settings updated through the collaboration session', async () => {
+    const original = initialJob();
+    const updated: CreatorJob = {
+      ...original,
+      revision: 1,
+      state: {
+        ...original.state,
+        topic: 'Agent 更新后的主题',
+        audience: '新手创作者',
+        style: 'review',
+        length: 'long',
+        extraRequirements: '只使用可核实的信息'
+      }
+    };
+    const applyAction = vi.fn(async (_jobId: string, request: CreatorActionRequest) => ({
+      job: { ...updated, revision: updated.revision + 1 },
+      receipt: {
+        actor: request.actor ?? 'user' as const,
+        action: request.action,
+        summary: request.action,
+        affectedArtifacts: [],
+        newRevision: updated.revision + 1,
+        createdAt: updated.updatedAt
+      }
+    }));
+
+    render(
+      <LanguageProvider initialPreference="zh-CN">
+        <CreatorSessionProvider
+          initialJob={original}
+          service={{ applyAction, runAgentTurn: vi.fn() }}
+        >
+          <ApplyRemoteSnapshotButton job={updated} />
+          <XiaohongshuPostWorkspace onBack={vi.fn()} />
+        </CreatorSessionProvider>
+      </LanguageProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '应用远程更新' }));
+    await waitFor(() => expect(
+      screen.getByRole('textbox', { name: '小红书帖子主题或素材' })
+    ).toHaveValue('Agent 更新后的主题'));
+    expect(screen.getByRole('radio', { name: '真实测评' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: '详细' })).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: '生成帖子' }));
+    await waitFor(() => expect(applyAction).toHaveBeenCalledOnce());
+    expect(applyAction).toHaveBeenCalledWith(
+      original.id,
+      expect.objectContaining({ action: 'run-stage' })
+    );
+  });
+
+  it('clears the previous post while a newer artifact is loading', async () => {
+    const first = completedJob(initialJob());
+    const secondArtifact: CreatorArtifact = {
+      ...first.artifacts[0]!,
+      id: 'xiaohongshu_post_v2',
+      version: 2,
+      metadata: {
+        ...first.artifacts[0]!.metadata,
+        title: '第二版帖子',
+        resultVersion: 2
+      }
+    };
+    const second: CreatorJob = {
+      ...first,
+      revision: first.revision + 1,
+      artifacts: [...first.artifacts, secondArtifact],
+      state: { ...first.state, latestResultVersion: 2, resultVersion: 2 }
+    };
+    let resolveSecond!: (response: Response) => void;
+    const secondResponse = new Promise<Response>(resolve => { resolveSecond = resolve; });
+    const openArtifact = vi.fn(async (_jobId: string, artifactId: string) => {
+      if (artifactId === secondArtifact.id) return await secondResponse;
+      return new Response('# 第一版帖子\n');
+    });
+
+    render(
+      <LanguageProvider initialPreference="zh-CN">
+        <CreatorSessionProvider
+          initialJob={first}
+          service={{ applyAction: vi.fn(), openArtifact, runAgentTurn: vi.fn() }}
+        >
+          <ApplyRemoteSnapshotButton job={second} />
+          <XiaohongshuPostWorkspace onBack={vi.fn()} />
+        </CreatorSessionProvider>
+      </LanguageProvider>
+    );
+
+    expect(await screen.findByRole('textbox', { name: '生成的小红书帖子' }))
+      .toHaveValue('# 第一版帖子\n');
+    fireEvent.click(screen.getByRole('button', { name: '应用远程更新' }));
+    await waitFor(() => expect(
+      screen.queryByRole('textbox', { name: '生成的小红书帖子' })
+    ).not.toBeInTheDocument());
+
+    resolveSecond(new Response('# 第二版帖子\n'));
+    expect(await screen.findByRole('textbox', { name: '生成的小红书帖子' }))
+      .toHaveValue('# 第二版帖子\n');
+  });
+});
+
+function ApplyRemoteSnapshotButton(props: { job: CreatorJob }) {
+  const session = useOptionalCreatorSession();
+  return (
+    <button type="button" onClick={() => session?.applyRemoteSnapshot(props.job)}>
+      应用远程更新
+    </button>
+  );
+}
+
+function initialJob(): CreatorJob {
+  return {
+    id: 'xiaohongshu_job',
+    projectId: 'project_1',
+    templateId: 'xiaohongshu-post',
+    templateVersion: 1,
+    status: 'draft',
+    revision: 0,
+    state: {
+      topic: '',
+      audience: '',
+      style: 'experience',
+      length: 'medium',
+      extraRequirements: '',
+      currentStage: null
+    },
+    agentThreadId: null,
+    stages: [],
+    artifacts: [],
+    activities: [],
+    createdAt: '2026-09-08T08:00:00.000Z',
+    updatedAt: '2026-09-08T08:00:00.000Z'
+  };
+}
+
+function completedJob(job: CreatorJob): CreatorJob {
+  const artifact: CreatorArtifact = {
+    id: 'xiaohongshu_post_v1',
+    jobId: job.id,
+    kind: 'xiaohongshu_post',
+    version: 1,
+    status: 'completed',
+    path: '/tmp/OpenCreator-xiaohongshu-post.md',
+    sourceArtifactIds: [],
+    metadata: {
+      fileName: 'OpenCreator-xiaohongshu-post.md',
+      title: '第一次参与开源项目',
+      resultVersion: 1
+    },
+    createdAt: '2026-09-08T08:01:00.000Z'
+  };
+  return {
+    ...job,
+    status: 'completed',
+    revision: job.revision + 2,
+    state: {
+      ...job.state,
+      currentStage: 'generate',
+      resultVersion: 1,
+      latestResultVersion: 1
+    },
+    stages: [{
+      id: 'xiaohongshu_stage_v1',
+      jobId: job.id,
+      stageId: 'generate',
+      executor: 'xiaohongshu-post',
+      status: 'succeeded',
+      dispatchStatus: 'finished',
+      claimOwner: null,
+      claimExpiresAt: null,
+      attempt: 1,
+      idempotencyKey: null,
+      progress: {
+        phase: 'completed',
+        percent: 100,
+        completed: 1,
+        failed: 0,
+        total: 1,
+        resultVersion: 1
+      },
+      errorCode: null,
+      errorMessage: null,
+      startedAt: '2026-09-08T08:00:30.000Z',
+      finishedAt: '2026-09-08T08:01:00.000Z'
+    }],
+    artifacts: [artifact],
+    updatedAt: '2026-09-08T08:01:00.000Z'
+  };
+}

--- a/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.test.tsx
+++ b/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.test.tsx
@@ -185,6 +185,47 @@ describe('XiaohongshuPostWorkspace', () => {
     expect(await screen.findByRole('textbox', { name: '生成的小红书帖子' }))
       .toHaveValue('# 第二版帖子\n');
   });
+
+  it('releases the download URL after the browser starts the download', async () => {
+    const createObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+    const revokeObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+    const createObjectURL = vi.fn(() => 'blob:xiaohongshu-post');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    try {
+      render(
+        <LanguageProvider initialPreference="zh-CN">
+          <CreatorSessionProvider
+            initialJob={completedJob(initialJob())}
+            service={{
+              applyAction: vi.fn(),
+              openArtifact: vi.fn(async () => new Response('# 可下载的帖子\n')),
+              runAgentTurn: vi.fn()
+            }}
+          >
+            <XiaohongshuPostWorkspace onBack={vi.fn()} />
+          </CreatorSessionProvider>
+        </LanguageProvider>
+      );
+
+      expect(await screen.findByRole('textbox', { name: '生成的小红书帖子' }))
+        .toHaveValue('# 可下载的帖子\n');
+      fireEvent.click(screen.getByRole('button', { name: '下载 Markdown' }));
+
+      expect(anchorClick).toHaveBeenCalledOnce();
+      expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+      expect(revokeObjectURL).not.toHaveBeenCalled();
+      await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:xiaohongshu-post'));
+    } finally {
+      anchorClick.mockRestore();
+      restoreUrlMethod('createObjectURL', createObjectUrlDescriptor);
+      restoreUrlMethod('revokeObjectURL', revokeObjectUrlDescriptor);
+    }
+  });
 });
 
 function ApplyRemoteSnapshotButton(props: { job: CreatorJob }) {
@@ -274,4 +315,12 @@ function completedJob(job: CreatorJob): CreatorJob {
     artifacts: [artifact],
     updatedAt: '2026-09-08T08:01:00.000Z'
   };
+}
+
+function restoreUrlMethod(
+  key: 'createObjectURL' | 'revokeObjectURL',
+  descriptor: PropertyDescriptor | undefined
+) {
+  if (descriptor === undefined) delete (URL as unknown as Record<string, unknown>)[key];
+  else Object.defineProperty(URL, key, descriptor);
 }

--- a/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.tsx
+++ b/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.tsx
@@ -180,7 +180,7 @@ export default function XiaohongshuPostWorkspace(props: {
     link.href = url;
     link.download = result.fileName;
     link.click();
-    URL.revokeObjectURL(url);
+    window.setTimeout(() => URL.revokeObjectURL(url), 0);
     setNotice(l('帖子文件已开始下载', 'The post download has started'));
   }
 

--- a/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.tsx
+++ b/apps/web/src/features/dashboard/XiaohongshuPostWorkspace.tsx
@@ -1,0 +1,427 @@
+import type { CreatorArtifact, CreatorJson } from '@opencreator/protocol';
+import {
+  Copy,
+  Download,
+  LoaderCircle,
+  NotebookPen,
+  RotateCcw,
+  Sparkles
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useLocalizedCopy } from '../../i18n/useLocalizedCopy.js';
+import CreatorToolShell from './CreatorToolShell.js';
+import { useOptionalCreatorSession } from './creator-session-store.js';
+
+type PostStyle = 'experience' | 'tutorial' | 'recommendation' | 'review';
+type PostLength = 'short' | 'medium' | 'long';
+
+const styles: Array<{ value: PostStyle; zh: string; en: string }> = [
+  { value: 'experience', zh: '经验分享', en: 'Experience' },
+  { value: 'tutorial', zh: '教程干货', en: 'Tutorial' },
+  { value: 'recommendation', zh: '产品种草', en: 'Recommendation' },
+  { value: 'review', zh: '真实测评', en: 'Review' }
+];
+
+const lengths: Array<{ value: PostLength; zh: string; en: string }> = [
+  { value: 'short', zh: '精简', en: 'Short' },
+  { value: 'medium', zh: '标准', en: 'Standard' },
+  { value: 'long', zh: '详细', en: 'Detailed' }
+];
+
+export default function XiaohongshuPostWorkspace(props: {
+  onBack(): void;
+  promptHint?: string;
+}) {
+  const l = useLocalizedCopy();
+  const session = useOptionalCreatorSession();
+  const [topic, setTopic] = useState(() => readString(session?.state.topic));
+  const [audience, setAudience] = useState(() => readString(session?.state.audience));
+  const [style, setStyle] = useState<PostStyle>(() => readStyle(session?.state.style));
+  const [length, setLength] = useState<PostLength>(() => readLength(session?.state.length));
+  const [extraRequirements, setExtraRequirements] = useState(
+    () => readString(session?.state.extraRequirements)
+  );
+  const [resultText, setResultText] = useState('');
+  const [notice, setNotice] = useState('');
+  const [error, setError] = useState('');
+  const [taskControlPending, setTaskControlPending] = useState<'canceling' | 'resuming'>();
+  const result = useMemo(
+    () => readLatestResult(session?.job.artifacts ?? []),
+    [session?.job.artifacts]
+  );
+  const latestStage = session?.job.stages.filter(stage => stage.stageId === 'generate').at(-1);
+  const generating = latestStage?.status === 'queued' || latestStage?.status === 'running';
+  const runtimeError = latestStage?.status === 'failed'
+    ? generationError(latestStage.errorCode, latestStage.errorMessage, l)
+    : session?.error === null || session?.error === undefined
+      ? ''
+      : generationError(session.error.code, session.error.message, l);
+  const visibleError = error || runtimeError;
+
+  useEffect(() => {
+    setTopic(readString(session?.state.topic));
+    setAudience(readString(session?.state.audience));
+    setStyle(readStyle(session?.state.style));
+    setLength(readLength(session?.state.length));
+    setExtraRequirements(readString(session?.state.extraRequirements));
+  }, [
+    session?.state.topic,
+    session?.state.audience,
+    session?.state.style,
+    session?.state.length,
+    session?.state.extraRequirements
+  ]);
+
+  useEffect(() => {
+    setResultText('');
+    setError('');
+    if (session === null || result === undefined) {
+      return;
+    }
+    let active = true;
+    void session.openArtifact(result.artifact.id)
+      .then(async response => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const text = await response.text();
+        if (active) setResultText(text);
+      })
+      .catch(cause => {
+        if (active) setError(l(
+          '帖子内容加载失败，可以稍后重试或重新生成',
+          `The post failed to load: ${cause instanceof Error ? cause.message : String(cause)}`
+        ));
+      });
+    return () => { active = false; };
+  }, [l, result?.artifact.id, session?.openArtifact]);
+
+  function updateTopic(value: string) {
+    setTopic(value);
+    session?.updateDraft({ topic: value });
+    setError('');
+  }
+
+  function updateAudience(value: string) {
+    setAudience(value);
+    session?.updateDraft({ audience: value });
+    setError('');
+  }
+
+  function updateStyle(value: PostStyle) {
+    setStyle(value);
+    session?.updateDraft({ style: value });
+    setError('');
+  }
+
+  function updateLength(value: PostLength) {
+    setLength(value);
+    session?.updateDraft({ length: value });
+    setError('');
+  }
+
+  function updateExtraRequirements(value: string) {
+    setExtraRequirements(value);
+    session?.updateDraft({ extraRequirements: value });
+    setError('');
+  }
+
+  async function generate() {
+    if (generating) return;
+    if (session === null) {
+      setError(l(
+        '小红书帖子生成服务暂不可用，请检查 Runtime 连接',
+        'Post generation is unavailable. Check the Runtime connection.'
+      ));
+      return;
+    }
+    if (!topic.trim()) {
+      setError(l('请先填写创作主题或素材', 'Enter a topic or source material'));
+      return;
+    }
+    setError('');
+    setNotice('');
+    session.updateDraft({
+      topic: topic.trim(),
+      audience: audience.trim(),
+      style,
+      length,
+      extraRequirements: extraRequirements.trim()
+    }, { semantic: true });
+    try {
+      await session.flush();
+      await session.applyAction({
+        actor: 'user',
+        action: 'run-stage',
+        input: { stageId: 'generate' }
+      });
+      setNotice(l(
+        '生成任务已提交，完成后会自动显示帖子',
+        'Generation started. The post will appear automatically.'
+      ));
+    } catch (caught) {
+      const value = caught as { code?: string; message?: string };
+      setError(generationError(value.code ?? null, value.message ?? null, l));
+    }
+  }
+
+  async function copyResult() {
+    if (!resultText) return;
+    try {
+      await navigator.clipboard.writeText(resultText);
+      setNotice(l('帖子已复制到剪贴板', 'Post copied to the clipboard'));
+    } catch {
+      setError(l('复制失败，请手动选择帖子内容', 'Copy failed. Select the post manually.'));
+    }
+  }
+
+  function downloadResult() {
+    if (!result || !resultText) return;
+    const url = URL.createObjectURL(new Blob([resultText], { type: 'text/markdown;charset=utf-8' }));
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = result.fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+    setNotice(l('帖子文件已开始下载', 'The post download has started'));
+  }
+
+  async function cancelTask() {
+    if (session === null || taskControlPending !== undefined) return;
+    setTaskControlPending('canceling');
+    try {
+      await session.cancelJob();
+    } catch (caught) {
+      const value = caught as { code?: string; message?: string };
+      setError(generationError(value.code ?? null, value.message ?? null, l));
+    } finally {
+      setTaskControlPending(undefined);
+    }
+  }
+
+  async function resumeTask() {
+    if (session === null || taskControlPending !== undefined) return;
+    setTaskControlPending('resuming');
+    try {
+      await session.resumeJob();
+    } catch (caught) {
+      const value = caught as { code?: string; message?: string };
+      setError(generationError(value.code ?? null, value.message ?? null, l));
+    } finally {
+      setTaskControlPending(undefined);
+    }
+  }
+
+  const selectedStyle = styles.find(item => item.value === style) ?? styles[0]!;
+  const selectedLength = lengths.find(item => item.value === length) ?? lengths[1]!;
+  return (
+    <CreatorToolShell
+      title={l('小红书帖子生成器', 'Xiaohongshu Post Generator')}
+      subtitle={l('从主题和素材生成完整帖子', 'Turn a topic or source material into a complete post')}
+      context={result
+        ? result.title
+        : generating
+          ? l('正在生成帖子', 'Generating post')
+          : `${l(selectedStyle.zh, selectedStyle.en)} · ${l(selectedLength.zh, selectedLength.en)}`}
+      stepLabel={generating ? l('正在生成帖子', 'Generating post') : l('小红书帖子', 'Xiaohongshu post')}
+      currentIssue={visibleError || undefined}
+      suggestions={result
+        ? [l('标题更有吸引力', 'Make the title more engaging'), l('减少营销感', 'Make it less promotional')]
+        : [l('写成教程干货', 'Write a tutorial'), l('使用真诚自然的语气', 'Use a sincere, natural tone')]}
+      placeholder={props.promptHint ?? l(
+        '描述要调整的主题、受众、内容类型或篇幅',
+        'Describe changes to the topic, audience, style, or length'
+      )}
+      onBack={props.onBack}
+      onCancelTask={() => void cancelTask()}
+      onResumeTask={() => void resumeTask()}
+      taskControlPending={taskControlPending}
+      pageClassName="xiaohongshu-post-workspace-page"
+    >
+      <div className="creator-tool-stack xiaohongshu-post-stack">
+        <section className="creator-tool-panel" aria-labelledby="xiaohongshu-post-settings-title">
+          <div className="creator-tool-panel-heading">
+            <div>
+              <h2 id="xiaohongshu-post-settings-title">{l('创作设置', 'Post settings')}</h2>
+              <p>{l('提供事实、观点或产品素材，生成内容会以这些信息为准', 'Provide facts, ideas, or product material for the post')}</p>
+            </div>
+          </div>
+          <div className="xiaohongshu-post-fields">
+            <label className="creator-tool-field">
+              <span>{l('主题或素材', 'Topic or source material')}</span>
+              <textarea
+                rows={8}
+                maxLength={5000}
+                value={topic}
+                onChange={event => updateTopic(event.target.value)}
+                placeholder={l('输入要表达的主题、事实、观点或产品信息', 'Enter the topic, facts, ideas, or product details')}
+                aria-label={l('小红书帖子主题或素材', 'Post topic or source material')}
+              />
+            </label>
+            <label className="creator-tool-field">
+              <span>{l('目标读者', 'Audience')} <small>{l('选填', 'Optional')}</small></span>
+              <input
+                maxLength={500}
+                value={audience}
+                onChange={event => updateAudience(event.target.value)}
+                placeholder={l('例如：准备参与开源项目的程序员', 'For example: developers new to open source')}
+              />
+            </label>
+            <div className="xiaohongshu-post-control-group">
+              <span>{l('内容类型', 'Post type')}</span>
+              <div className="creator-tool-segmented" role="radiogroup" aria-label={l('内容类型', 'Post type')}>
+                {styles.map(item => (
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={style === item.value}
+                    aria-selected={style === item.value}
+                    key={item.value}
+                    onClick={() => updateStyle(item.value)}
+                  >
+                    {l(item.zh, item.en)}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="xiaohongshu-post-control-group">
+              <span>{l('内容篇幅', 'Length')}</span>
+              <div className="creator-tool-segmented" role="radiogroup" aria-label={l('内容篇幅', 'Length')}>
+                {lengths.map(item => (
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={length === item.value}
+                    aria-selected={length === item.value}
+                    key={item.value}
+                    onClick={() => updateLength(item.value)}
+                  >
+                    {l(item.zh, item.en)}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <label className="creator-tool-field">
+              <span>{l('补充要求', 'Additional requirements')} <small>{l('选填', 'Optional')}</small></span>
+              <textarea
+                rows={3}
+                maxLength={2000}
+                value={extraRequirements}
+                onChange={event => updateExtraRequirements(event.target.value)}
+                placeholder={l('例如：语气真诚，减少营销感', 'For example: sincere tone, less promotional')}
+              />
+            </label>
+          </div>
+          <div className="creator-tool-actions">
+            <button type="button" onClick={() => void generate()} disabled={generating}>
+              {generating
+                ? <LoaderCircle className="xiaohongshu-post-spinner" size={16} strokeWidth={1.8} aria-hidden="true" />
+                : result
+                  ? <RotateCcw size={16} strokeWidth={1.8} aria-hidden="true" />
+                  : <Sparkles size={16} strokeWidth={1.8} aria-hidden="true" />}
+              {generating
+                ? l('正在生成', 'Generating')
+                : result
+                  ? l('重新生成', 'Regenerate')
+                  : l('生成帖子', 'Generate post')}
+            </button>
+          </div>
+        </section>
+
+        <section className="creator-tool-panel xiaohongshu-post-result-panel" aria-labelledby="xiaohongshu-post-result-title">
+          <div className="creator-tool-panel-heading">
+            <div>
+              <h2 id="xiaohongshu-post-result-title">{l('帖子结果', 'Post result')}</h2>
+              <p>{result
+                ? l('可以复制到发布工具，或下载 Markdown 文件', 'Copy the post or download it as Markdown')
+                : l('完成创作设置后生成帖子', 'Complete the settings to generate a post')}</p>
+            </div>
+            {result ? <small><NotebookPen size={14} strokeWidth={1.8} aria-hidden="true" />{result.fileName}</small> : null}
+          </div>
+          {resultText ? (
+            <>
+              <label className="creator-tool-field">
+                <span>{l('完整帖子', 'Complete post')}</span>
+                <textarea readOnly rows={14} value={resultText} aria-label={l('生成的小红书帖子', 'Generated Xiaohongshu post')} />
+              </label>
+              <div className="creator-tool-actions xiaohongshu-post-result-actions">
+                <button className="creator-tool-secondary" type="button" onClick={() => void copyResult()}>
+                  <Copy size={15} strokeWidth={1.8} aria-hidden="true" />
+                  {l('复制帖子', 'Copy post')}
+                </button>
+                <button className="creator-tool-primary" type="button" onClick={downloadResult}>
+                  <Download size={15} strokeWidth={1.8} aria-hidden="true" />
+                  {l('下载 Markdown', 'Download Markdown')}
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="xiaohongshu-post-empty" aria-live="polite">
+              {generating
+                ? <LoaderCircle className="xiaohongshu-post-spinner" size={22} strokeWidth={1.7} aria-hidden="true" />
+                : <NotebookPen size={22} strokeWidth={1.7} aria-hidden="true" />}
+              <span>{generating ? l('正在生成帖子', 'Generating post') : l('还没有生成内容', 'No post generated yet')}</span>
+            </div>
+          )}
+        </section>
+
+        {visibleError ? (
+          <div className="xiaohongshu-post-error" role="alert">
+            <span>{visibleError}</span>
+            {latestStage?.errorCode === 'creator_llm_config_missing' || session?.error?.code === 'creator_llm_config_missing'
+              ? <a href="#/settings?tab=ai-services&section=text">{l('打开文本模型设置', 'Open text model settings')}</a>
+              : null}
+          </div>
+        ) : null}
+        {notice ? <p className="creator-tool-notice" role="status">{notice}</p> : null}
+      </div>
+    </CreatorToolShell>
+  );
+}
+
+function readLatestResult(artifacts: CreatorArtifact[]): {
+  artifact: CreatorArtifact;
+  fileName: string;
+  title: string;
+} | undefined {
+  const artifact = [...artifacts].reverse().find(candidate => (
+    candidate.kind === 'xiaohongshu_post'
+    && candidate.path !== null
+    && candidate.status === 'completed'
+  ));
+  if (artifact === undefined) return undefined;
+  return {
+    artifact,
+    fileName: readString(artifact.metadata.fileName) || 'OpenCreator-xiaohongshu-post.md',
+    title: readString(artifact.metadata.title) || '小红书帖子'
+  };
+}
+
+function readStyle(value: CreatorJson | undefined): PostStyle {
+  return value === 'tutorial' || value === 'recommendation' || value === 'review'
+    ? value
+    : 'experience';
+}
+
+function readLength(value: CreatorJson | undefined): PostLength {
+  return value === 'short' || value === 'long' ? value : 'medium';
+}
+
+function readString(value: CreatorJson | undefined): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function generationError(
+  code: string | null,
+  message: string | null,
+  l: (zh: string, en: string) => string
+): string {
+  if (code === 'creator_llm_config_missing') {
+    return l(
+      '请先在设置的 AI 服务中配置文本模型',
+      'Configure a text model in AI Services first'
+    );
+  }
+  if (code === 'creator_stage_input_missing') {
+    return l('请检查创作主题和生成设置', 'Check the topic and generation settings');
+  }
+  return message || l('帖子生成失败，请稍后重试', 'Post generation failed. Try again later.');
+}

--- a/apps/web/src/features/dashboard/creator-panel-adapters.ts
+++ b/apps/web/src/features/dashboard/creator-panel-adapters.ts
@@ -353,6 +353,53 @@ export const smartDubbingPanelAdapter: CreatorPanelAdapter = {
   }
 };
 
+export const xiaohongshuPostPanelAdapter: CreatorPanelAdapter = {
+  id: 'xiaohongshu-post',
+  composerPlaceholder: l => l(
+    '询问生成状态，或调整主题、受众、内容类型和篇幅',
+    'Ask about progress or adjust the topic, audience, style, and length'
+  ),
+  stageLabel(stageId, l) {
+    if (stageId === 'generate') return l('生成小红书帖子', 'Generate Xiaohongshu post');
+    return l('小红书帖子任务', 'Xiaohongshu post task');
+  },
+  phaseLabel(phase, l) {
+    const labels: Record<string, string> = {
+      validating: l('检查帖子设置', 'Checking post settings'),
+      generating_post: l('生成帖子内容', 'Generating post content'),
+      completed: l('帖子已生成', 'Post generated')
+    };
+    return labels[phase] ?? genericPhaseLabel(phase, l);
+  },
+  activityStageId: readActivityStageId,
+  normalizeActivity(activity, l) {
+    return normalizeCommonActivity(
+      activity,
+      l,
+      xiaohongshuPostPanelAdapter,
+      {},
+      xiaohongshuPostFieldLabel
+    );
+  },
+  readStageProgress: readStandardProgress,
+  runningProgressText(_stage, progress, l) {
+    return progress.phase === null
+      ? null
+      : xiaohongshuPostPanelAdapter.phaseLabel(progress.phase, l);
+  },
+  failedProgressText(stage, l) {
+    return stage.errorCode === 'creator_llm_config_missing'
+      ? l(
+          '请先在设置的 AI 服务中配置文本模型',
+          'Configure a text model in AI Services first.'
+        )
+      : null;
+  },
+  succeededProgressText(_stage, l) {
+    return l('帖子已生成，可以复制或下载', 'The post is ready to copy or download');
+  }
+};
+
 export const videoGenerationPanelAdapter: CreatorPanelAdapter = {
   id: 'video-generation',
   composerPlaceholder: l => l(
@@ -432,6 +479,7 @@ export function creatorPanelAdapterFor(templateId: string): CreatorPanelAdapter 
   if (templateId === 'video-translation') return videoTranslationPanelAdapter;
   if (templateId === 'video-download') return videoDownloadPanelAdapter;
   if (templateId === 'smart-dubbing') return smartDubbingPanelAdapter;
+  if (templateId === 'xiaohongshu-post') return xiaohongshuPostPanelAdapter;
   if (templateId === 'cover') return coverPanelAdapter;
   if (templateId === 'video-generation') return videoGenerationPanelAdapter;
   return genericAdapter;
@@ -575,6 +623,20 @@ function smartDubbingFieldLabel(
     style: l('表达风格', 'Delivery style'),
     speed: l('语速', 'Speaking rate'),
     format: l('音频格式', 'Audio format')
+  };
+  return labels[field] ?? null;
+}
+
+function xiaohongshuPostFieldLabel(
+  field: string,
+  l: CreatorPanelLocalize
+): string | null {
+  const labels: Record<string, string> = {
+    topic: l('主题或素材', 'Topic or source material'),
+    audience: l('目标读者', 'Audience'),
+    style: l('内容类型', 'Post type'),
+    length: l('内容篇幅', 'Length'),
+    extraRequirements: l('补充要求', 'Additional requirements')
   };
   return labels[field] ?? null;
 }

--- a/apps/web/src/features/dashboard/creator-workspace.ts
+++ b/apps/web/src/features/dashboard/creator-workspace.ts
@@ -4,6 +4,7 @@ export type CreatorWorkspace =
   | 'stickman-video'
   | 'auto-clips'
   | 'smart-dubbing'
+  | 'xiaohongshu-post'
   | 'digital-avatar'
   | 'cover-generator'
   | 'image-generation'
@@ -15,6 +16,7 @@ export const creatorWorkspaces = [
   'stickman-video',
   'auto-clips',
   'smart-dubbing',
+  'xiaohongshu-post',
   'digital-avatar',
   'cover-generator',
   'image-generation',
@@ -25,6 +27,7 @@ export const visibleCreatorWorkspaces = [
   'video-translation',
   'video-download',
   'smart-dubbing',
+  'xiaohongshu-post',
   'cover-generator',
   'image-generation',
   'video-generation'
@@ -36,6 +39,7 @@ export const creatorRuntimeWorkspaces = [
   'stickman-video',
   'auto-clips',
   'smart-dubbing',
+  'xiaohongshu-post',
   'cover-generator',
   'image-generation',
   'video-generation'
@@ -49,6 +53,7 @@ const templateByWorkspace: Record<CreatorRuntimeWorkspace, string> = {
   'stickman-video': 'stickman-video',
   'auto-clips': 'auto-clip',
   'smart-dubbing': 'smart-dubbing',
+  'xiaohongshu-post': 'xiaohongshu-post',
   'cover-generator': 'cover',
   'image-generation': 'image-generation',
   'video-generation': 'video-generation'

--- a/apps/web/src/features/dashboard/dashboard.css
+++ b/apps/web/src/features/dashboard/dashboard.css
@@ -2917,6 +2917,131 @@
   border-top: 1px solid var(--border-hairline);
 }
 
+.xiaohongshu-post-fields,
+.xiaohongshu-post-control-group {
+  display: grid;
+  gap: 14px;
+}
+
+.xiaohongshu-post-control-group {
+  gap: 8px;
+}
+
+.xiaohongshu-post-control-group > span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 560;
+}
+
+.xiaohongshu-post-control-group .creator-tool-segmented {
+  max-width: 100%;
+  flex-wrap: wrap;
+  margin: 0;
+}
+
+.xiaohongshu-post-result-panel textarea {
+  min-height: 300px;
+}
+
+.xiaohongshu-post-result-panel .creator-tool-panel-heading > small {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--subtle);
+  text-overflow: ellipsis;
+}
+
+.xiaohongshu-post-result-actions {
+  margin-top: 12px;
+}
+
+.xiaohongshu-post-empty {
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 9px;
+  border: 1px dashed var(--border);
+  border-radius: 7px;
+  background: var(--conversation-bg);
+  color: var(--subtle);
+  font-size: 12px;
+}
+
+.xiaohongshu-post-error {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 11px;
+  border-left: 2px solid #c94b4b;
+  background: color-mix(in srgb, #c94b4b 7%, var(--surface));
+  color: #b33d3d;
+  font-size: 12px;
+}
+
+.xiaohongshu-post-error a {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-weight: 620;
+  text-decoration: none;
+}
+
+.xiaohongshu-post-error a:hover {
+  text-decoration: underline;
+}
+
+.xiaohongshu-post-spinner {
+  animation: smart-dubbing-spin 0.9s linear infinite;
+}
+
+@media (max-width: 960px) {
+  .xiaohongshu-post-workspace-page {
+    height: auto;
+    min-height: 100%;
+    overflow-y: auto;
+  }
+
+  .xiaohongshu-post-workspace-page .creator-workspace-layout {
+    min-width: 0;
+    height: auto;
+    min-height: 100%;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .xiaohongshu-post-workspace-page .creator-workspace-main,
+  .xiaohongshu-post-workspace-page .creator-workspace-content {
+    overflow: visible;
+  }
+
+  .xiaohongshu-post-workspace-page .creator-workspace-main {
+    border-right: 0;
+  }
+
+  .xiaohongshu-post-workspace-page .creator-workspace-content {
+    scrollbar-gutter: auto;
+  }
+
+  .xiaohongshu-post-workspace-page .creator-collaboration-panel {
+    min-width: 0;
+    height: auto;
+    min-height: 640px;
+    border-top: 1px solid var(--border-hairline);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 500px) {
+  .xiaohongshu-post-control-group .creator-tool-segmented button {
+    padding: 0 7px;
+    font-size: 11px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xiaohongshu-post-spinner { animation: none; }
+}
+
 .smart-dubbing-spinner {
   animation: smart-dubbing-spin 0.9s linear infinite;
 }

--- a/apps/web/src/features/projects/ProjectsPage.test.tsx
+++ b/apps/web/src/features/projects/ProjectsPage.test.tsx
@@ -446,6 +446,48 @@ describe('ProjectsPage', () => {
       .toHaveAttribute('src', '/dashboard/templates/image-generation-project-cover.png');
   });
 
+  it('lists Xiaohongshu posts as writing projects and hides untouched drafts', () => {
+    const empty = creatorJob({
+      id: 'job_xiaohongshu_empty',
+      templateId: 'xiaohongshu-post',
+      state: {
+        topic: '',
+        audience: '',
+        style: 'experience',
+        length: 'medium',
+        extraRequirements: '',
+        currentStage: null
+      },
+      updatedAt: '2026-09-08T08:00:00.000Z'
+    });
+    const generated = creatorJob({
+      id: 'job_xiaohongshu_generated',
+      templateId: 'xiaohongshu-post',
+      state: { ...empty.state, topic: '第一次参与开源项目' },
+      updatedAt: '2026-09-08T08:10:00.000Z',
+      artifacts: [artifact('job_xiaohongshu_generated', 'xiaohongshu_post', 'post.md')]
+    });
+
+    expect(isMeaningfulCreatorJob(empty)).toBe(false);
+    render(
+      <ProjectsPage
+        jobs={[empty, generated]}
+        workspaces={workspaces}
+        onOpenJob={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: '文案创作' }));
+    const project = screen.getByRole('button', { name: '打开项目 第一次参与开源项目' });
+    expect(project).toHaveTextContent('小红书帖子');
+    expect(project.querySelector('img')).toHaveAttribute(
+      'src',
+      '/dashboard/templates/digital-presenter.jpg'
+    );
+    expect(within(screen.getByRole('list', { name: '项目列表' })).getAllByRole('listitem'))
+      .toHaveLength(1);
+  });
+
   it('shows loading and runtime errors explicitly', () => {
     const { rerender } = render(
       <ProjectsPage jobs={[]} workspaces={workspaces} loading onOpenJob={vi.fn()} />

--- a/apps/web/src/features/projects/ProjectsPage.tsx
+++ b/apps/web/src/features/projects/ProjectsPage.tsx
@@ -13,7 +13,7 @@ import type { CreatorWebService } from '../../services/creator-service.js';
 import type { OpenCreatorProject } from './project-model.js';
 import './projects-page.css';
 
-const projectCategories = ['全部', '视频创作', '图像设计'] as const;
+const projectCategories = ['全部', '视频创作', '图像设计', '文案创作'] as const;
 type ProjectCategory = typeof projectCategories[number];
 const projectCoverArtifactKinds = new Set([
   'cover_image',
@@ -271,7 +271,9 @@ function createCreatorProject(
     title: creatorProjectTitle(job, type),
     category: job.templateId === 'cover' || job.templateId === 'image-generation'
       ? '图像设计'
-      : '视频创作',
+      : job.templateId === 'xiaohongshu-post'
+        ? '文案创作'
+        : '视频创作',
     workspaceName: workspaces.find(workspace => workspace.id === job.projectId)?.name
       ?? l('未知工作目录', 'Unknown workspace'),
     cover: projectCover(job.templateId),
@@ -383,6 +385,16 @@ function creatorDraftDefaults(templateId: string): Record<string, unknown[]> {
       selectedCandidateIds: [['1', '2', '3']]
     };
   }
+  if (templateId === 'xiaohongshu-post') {
+    return {
+      topic: [''],
+      audience: [''],
+      style: ['experience'],
+      length: ['medium'],
+      extraRequirements: [''],
+      currentStage: [null]
+    };
+  }
   if (templateId === 'stickman-video') {
     return {
       topic: [
@@ -489,12 +501,14 @@ function templateLabel(templateId: string, l: LocalizeCopy): string | undefined 
   if (templateId === 'image-generation') return l('图像生成', 'Image generation');
   if (templateId === 'video-generation') return l('视频生成', 'Video generation');
   if (templateId === 'stickman-video') return l('火柴人视频', 'Stick figure video');
+  if (templateId === 'xiaohongshu-post') return l('小红书帖子', 'Xiaohongshu post');
   return undefined;
 }
 
 function localizeProjectCategory(category: ProjectCategory, l: LocalizeCopy): string {
   if (category === '全部') return l(category, 'All');
   if (category === '图像设计') return l(category, 'Image Design');
+  if (category === '文案创作') return l(category, 'Writing');
   return l(category, 'Video Creation');
 }
 
@@ -518,6 +532,7 @@ function projectCover(templateId: string): string {
   if (templateId === 'video-generation') return '/dashboard/templates/animated-story.jpg';
   if (templateId === 'stickman-video') return '/dashboard/templates/ai-video-insane.jpg';
   if (templateId === 'auto-clip') return '/dashboard/templates/animated-story.jpg';
+  if (templateId === 'xiaohongshu-post') return '/dashboard/templates/digital-presenter.jpg';
   return '/dashboard/templates/digital-presenter.jpg';
 }
 


### PR DESCRIPTION
## Summary

- add a Xiaohongshu post generator for topics, source material, audience, post type, and length
- generate and persist a Markdown result with copy and download actions
- expose the workflow from the creator workbench and project list

## Architecture

- reuse the Creator Template, Stage Executor, Job, Artifact, and ResultSnapshot flow
- reuse the shared CreatorCollaborationPanel through a Xiaohongshu adapter
- use the configured OpenAI-compatible text model and validate its JSON response with Zod

## Validation

- daemon typecheck
- web typecheck
- daemon targeted tests: 13 passed
- web targeted tests: 68 passed
- Xiaohongshu workspace regression tests after review fixes: 4 passed
- Browser/Desktop parity spec: 1 passed
- manual visual checks at 1440x900 and 390x844
- git diff --check

## Not tested

- packaged Desktop app E2E and embedded Web asset hash verification